### PR TITLE
update project to work on mac again (10.9)

### DIFF
--- a/GNUstep.h
+++ b/GNUstep.h
@@ -1,0 +1,188 @@
+/* GNUstep.h - macros to make easier to port gnustep apps to macos-x
+   Copyright (C) 2001 Free Software Foundation, Inc.
+ 
+   Written by: Nicola Pero
+   Date: March, October 2001
+ 
+   This file is part of GNUstep.
+ 
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+ 
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+ 
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+ */
+
+#ifndef Performance_GNUstep_h
+#define Performance_GNUstep_h
+
+#ifndef	RETAIN
+/**
+ *	Basic retain operation ... calls [NSObject-retain]<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	RETAIN(object)		[(id)(object) retain]
+#endif
+
+#ifndef	RELEASE
+/**
+ *	Basic release operation ... calls [NSObject-release]<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	RELEASE(object)		[(id)(object) release]
+#endif
+
+#ifndef	AUTORELEASE
+/**
+ *	Basic autorelease operation ... calls [NSObject-autorelease]<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	AUTORELEASE(object)	[(id)(object) autorelease]
+#endif
+
+#ifndef	TEST_RETAIN
+/**
+ *	Tested retain - only invoke the
+ *	objective-c method if the receiver is not nil.<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	TEST_RETAIN(object)	({\
+void *__object = (void*)(object);\
+(__object != 0) ? [(id)__object retain] : nil; })
+#endif
+
+#ifndef	TEST_RELEASE
+/**
+ *	Tested release - only invoke the
+ *	objective-c method if the receiver is not nil.<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	TEST_RELEASE(object)	({\
+void *__object = (void*)(object);\
+if (__object != 0) [(id)__object release]; })
+#endif
+
+#ifndef	TEST_AUTORELEASE
+/**
+ *	Tested autorelease - only invoke the
+ *	objective-c method if the receiver is not nil.<br />
+ *	Does nothing when ARC is in use.
+ */
+#define	TEST_AUTORELEASE(object)	({\
+void *__object = (void*)(object);\
+(__object != 0) ? [(id)__object autorelease] : nil; })
+#endif
+
+#ifndef	ASSIGN
+/**
+ *	ASSIGN(object,value) assigns the value to the object with
+ *	appropriate retain and release operations.<br />
+ *	Use this to avoid retain/release errors.
+ */
+#define	ASSIGN(object,value)	({\
+void *__object = (void*)object; \
+object = (__typeof__(object))[(value) retain]; \
+[(id)__object release]; \
+})
+#endif
+
+#ifndef	ASSIGNCOPY
+/**
+ *	ASSIGNCOPY(object,value) assigns a copy of the value to the object
+ *	with release of the original.<br />
+ *	Use this to avoid retain/release errors.
+ */
+#define	ASSIGNCOPY(object,value)	({\
+void *__object = (void*)object; \
+object = (__typeof__(object))[(value) copy];\
+[(id)__object release]; \
+})
+#endif
+
+#ifndef	ASSIGNMUTABLECOPY
+/**
+ *	ASSIGNMUTABLECOPY(object,value) assigns a mutable copy of the value
+ *	to the object with release of the original.<br />
+ *	Use this to avoid retain/release errors.
+ */
+#define	ASSIGNMUTABLECOPY(object,value)	({\
+void *__object = (void*)object; \
+object = (__typeof__(object))[(value) mutableCopy];\
+[(id)__object release]; \
+})
+#endif
+
+#ifndef	DESTROY
+/**
+ *	DESTROY() is a release operation which also sets the variable to be
+ *	a nil pointer for tidiness - we can't accidentally use a DESTROYED
+ *	object later.  It also makes sure to set the variable to nil before
+ *	releasing the object - to avoid side-effects of the release trying
+ *	to reference the object being released through the variable.
+ */
+#define	DESTROY(object) 	({ \
+void *__o = (void*)object; \
+object = nil; \
+[(id)__o release]; \
+})
+#endif
+
+#ifndef DEALLOC
+/**
+ *	DEALLOC calls the superclass implementation of dealloc, unless
+ *	ARC is in use (in which case it does nothing).
+ */
+#define DEALLOC         [super dealloc];
+#endif
+
+#ifndef ENTER_POOL
+/**
+ *	ENTER_POOL creates an autorelease pool and places subsequent code
+ *	in a block.<br />
+ *	The block must be terminated with a corresponding LEAVE_POOL.<br />
+ *	You should not break, continue, or return from such a block of code
+ *	(to do so could leak an autorelease pool and give objects a longer
+ *	lifetime than they ought to have.  If you wish to leave the block of
+ *	code early, you should ensure that doing so causes the autorelease
+ *	pool outside the block to be released promptly (since that will
+ *	implicitly release the pool created at the start of the block too).
+ */
+#define ENTER_POOL      {NSAutoreleasePool *_lARP=[NSAutoreleasePool new];
+#endif
+
+#ifndef LEAVE_POOL
+/**
+ *	LEAVE_POOL terminates a block of code started with ENTER_POOL.
+ */
+#define LEAVE_POOL      [_lARP drain];}
+#endif
+
+
+#ifndef __has_feature      // Optional.
+#define __has_feature(x) 0 // Compatibility with non-clang compilers.
+#endif
+
+#ifndef NS_CONSUMED
+#if __has_feature(attribute_ns_consumed)
+#define NS_CONSUMED __attribute__((ns_consumed))
+#else
+#define NS_CONSUMED
+#endif
+#endif
+
+//Let's add some very crude substitutions
+#define NSDebugFLog(format, args...) NSLog(format, args)
+#define NSDebugMLog(format, args...) NSLog(format, args)
+#define NSWarnMLog(format, args...) NSLog(format, args)
+
+
+#endif

--- a/GWSCoder.m
+++ b/GWSCoder.m
@@ -151,7 +151,7 @@ static id       boolY;
           NSWarnMLog(@"No separate class for the sloppy parser. All parsers "
                      @"will be sloppy.");
 #else
-          NSWarnMLog(@"No separate class for the sloppy parser. All parsers "
+          NSWarnMLog(@"No separate class for the sloppy parser. All parsers ",
                      @"will be strict.");
 #endif
         }

--- a/GWSPrivate.h
+++ b/GWSPrivate.h
@@ -45,19 +45,9 @@
 #import "GWSService.h"
 #import "GWSType.h"
 
+
 #if !defined(GNUSTEP)
-//Let's add some very crude substitutions
-#define NSDebugFLog(format, args...) NSLog(format, args)
-#define NSDebugMLog(format, args...) NSLog(format, args)
-
-#ifndef	ASSIGN
-#define	ASSIGN(object,value)	object = (value)
-#endif
-
-
-#if (MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_4)
-typedef int NSInteger;
-#endif
+#import  "GNUstep.h"
 #endif
 
 @interface      GWSBinding (Private)

--- a/WSSUsernameToken.m
+++ b/WSSUsernameToken.m
@@ -35,6 +35,10 @@
 #include <nettle/sha3.h>
 #endif
 
+#if !defined (GNUSTEP)
+#import  "GNUstep.h"
+#endif
+
 static NSTimeZone	*gmt = nil;
 static GWSCoder		*coder = nil;
 

--- a/WebServices.xcodeproj/project.pbxproj
+++ b/WebServices.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 42;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -34,12 +34,15 @@
 		79DC40BE0ED21ED9009451BF /* GWSPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 79DC40B70ED21E79009451BF /* GWSPort.m */; };
 		79E778FE0D5BB5DE000C97BA /* GWSDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 792C21700D55B94900459A2C /* GWSDocument.m */; };
 		79E778FF0D5BB5E1000C97BA /* GWSDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 792C216F0D55B94900459A2C /* GWSDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8591FB731A12E2F300923420 /* Performance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8591FA991A12E27A00923420 /* Performance.framework */; };
 		8591FBC71A12E74600923420 /* GWSHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 8591FBC41A12E74600923420 /* GWSHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8591FBC81A12E74600923420 /* GWSHash.m in Sources */ = {isa = PBXBuildFile; fileRef = 8591FBC51A12E74600923420 /* GWSHash.m */; };
 		8591FBE61A12E85800923420 /* GWSJSONCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8591FBE31A12E85800923420 /* GWSJSONCoder.m */; };
 		8591FBE71A12E85800923420 /* WSSUsernameToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 8591FBE41A12E85800923420 /* WSSUsernameToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8591FBE81A12E85800923420 /* WSSUsernameToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 8591FBE51A12E85800923420 /* WSSUsernameToken.m */; };
+		85DA4C022C41DC3500FC0E77 /* Performance.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8591FA991A12E27A00923420 /* Performance.framework */; };
+		85DA4C042C41DF8A00FC0E77 /* GNUstep.h in Headers */ = {isa = PBXBuildFile; fileRef = 85DA4C032C41DF8A00FC0E77 /* GNUstep.h */; };
+		85DA4C062C41E1D700FC0E77 /* libgnutls.30.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 85DA4C052C41E1D700FC0E77 /* libgnutls.30.dylib */; };
+		85DA4C082C41E22800FC0E77 /* libnettle.8.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 85DA4C072C41E22800FC0E77 /* libnettle.8.8.dylib */; };
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
 /* End PBXBuildFile section */
@@ -93,6 +96,9 @@
 		8591FBE31A12E85800923420 /* GWSJSONCoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GWSJSONCoder.m; sourceTree = "<group>"; };
 		8591FBE41A12E85800923420 /* WSSUsernameToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WSSUsernameToken.h; sourceTree = "<group>"; };
 		8591FBE51A12E85800923420 /* WSSUsernameToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WSSUsernameToken.m; sourceTree = "<group>"; };
+		85DA4C032C41DF8A00FC0E77 /* GNUstep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GNUstep.h; sourceTree = "<group>"; };
+		85DA4C052C41E1D700FC0E77 /* libgnutls.30.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libgnutls.30.dylib; path = ../../../../opt/local/lib/libgnutls.30.dylib; sourceTree = "<group>"; };
+		85DA4C072C41E22800FC0E77 /* libnettle.8.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libnettle.8.8.dylib; path = ../../../../opt/local/lib/libnettle.8.8.dylib; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* WebServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WebServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
@@ -111,8 +117,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				85DA4C082C41E22800FC0E77 /* libnettle.8.8.dylib in Frameworks */,
 				8DC2EF570486A6940098B216 /* Cocoa.framework in Frameworks */,
-				8591FB731A12E2F300923420 /* Performance.framework in Frameworks */,
+				85DA4C062C41E1D700FC0E77 /* libgnutls.30.dylib in Frameworks */,
+				85DA4C022C41DC3500FC0E77 /* Performance.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -162,6 +170,7 @@
 		08FB77AEFE84172EC02AAC07 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				85DA4C032C41DF8A00FC0E77 /* GNUstep.h */,
 				8591FBE31A12E85800923420 /* GWSJSONCoder.m */,
 				8591FBE41A12E85800923420 /* WSSUsernameToken.h */,
 				8591FBE51A12E85800923420 /* WSSUsernameToken.m */,
@@ -207,6 +216,8 @@
 		1058C7B2FEA5585E11CA2CBB /* Other Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				85DA4C072C41E22800FC0E77 /* libnettle.8.8.dylib */,
+				85DA4C052C41E1D700FC0E77 /* libgnutls.30.dylib */,
 				0867D6A5FE840307C02AAC07 /* AppKit.framework */,
 				D2F7E79907B2D74100F64583 /* CoreData.framework */,
 				0867D69BFE84028FC02AAC07 /* Foundation.framework */,
@@ -235,6 +246,7 @@
 				791866DD0D4A46A1003EBF9C /* GWSConstants.h in Headers */,
 				791866DE0D4A46A1003EBF9C /* GWSElement.h in Headers */,
 				791866E20D4A46A1003EBF9C /* GWSMessage.h in Headers */,
+				85DA4C042C41DF8A00FC0E77 /* GNUstep.h in Headers */,
 				791866E40D4A46A1003EBF9C /* GWSPortType.h in Headers */,
 				791866E60D4A46A1003EBF9C /* GWSPrivate.h in Headers */,
 				791866E70D4A46A1003EBF9C /* GWSService.h in Headers */,
@@ -292,8 +304,11 @@
 /* Begin PBXProject section */
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "WebServices" */;
-			compatibilityVersion = "Xcode 2.4";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -380,9 +395,14 @@
 		1DEB91AE08733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
 				FRAMEWORK_VERSION = A;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
@@ -390,9 +410,22 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WebServices_Prefix.pch;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"find:",
+					"/Library/Caches/com.apple.Spotlight:",
+					Permission,
+					"denied\n/opt/local/include/",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/opt/local/lib,
+				);
 				PRODUCT_NAME = WebServices;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 				ZERO_LINK = YES;
 			};
@@ -401,17 +434,35 @@
 		1DEB91AF08733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
 				FRAMEWORK_VERSION = A;
 				GCC_ENABLE_EXCEPTIONS = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WebServices_Prefix.pch;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"find:",
+					"/Library/Caches/com.apple.Spotlight:",
+					Permission,
+					"denied\n/opt/local/include/",
+				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/opt/local/lib,
+				);
 				PRODUCT_NAME = WebServices;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;
@@ -419,12 +470,11 @@
 		1DEB91B208733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1 = "ppc i386";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				SYMROOT = "$(PROJECT_DIR)/build";
 			};
 			name = Debug;
@@ -432,12 +482,10 @@
 		1DEB91B308733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1 = "ppc i386";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = /Developer/SDKs/MacOSX10.5.sdk;
+				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				SYMROOT = "$(PROJECT_DIR)/build";
 			};
 			name = Release;


### PR DESCRIPTION
Make work on Mac again - 10.9 since it has TLS 1.3
Remove hacks for 10.4 and earlier

Cleanup usage of GNUstep macros, specify GNUstep.h as compatibility, put macros inside and try to use GNUstep memory macros missed in some spots.